### PR TITLE
fix code alignment in chat app

### DIFF
--- a/R/html_to_taglist.R
+++ b/R/html_to_taglist.R
@@ -139,6 +139,9 @@ node_params_to_str <- function(node_params) {
   } else {
     tag_name <- glue::glue("htmltools::tags${node_params$name}")
     params <- attrs_to_params(node_params$attrs)
+    if (node_params$name == "code") {
+      params = c(params, '.noWS="outside"')
+    }
     contents <- node_params$contents
     if (length(contents) > 0) {
       contents <- contents %>%

--- a/inst/css/mod_app.css
+++ b/inst/css/mod_app.css
@@ -14,3 +14,8 @@
 ::-webkit-scrollbar-thumb:hover {
   background: #999;
 }
+
+/* Fix response alignment */
+pre code {
+  display: block;
+}


### PR DESCRIPTION
Hi,

It seems that in the latest version the code in the `<pre><code>` tags of the chat app is not properly left-aligned.
![image](https://user-images.githubusercontent.com/671660/235671519-c747a1a4-f37d-4e1c-b5a7-32564ca89ef3.png)

This PR fixes this:

![image](https://user-images.githubusercontent.com/671660/235671982-501a27aa-7543-40bd-a14c-456bb16689a5.png)

