### PR TITLE
Fix text insertion from "edit" addins

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gptstudio
 Title: Use Large Language Models Directly in your Development Environment
-Version: 0.2.0.9000
+Version: 0.2.0.9001
 Authors@R: c(
     person("Michel", "Nivard", , "m.g.nivard@vu.nl", role = c("aut", "cph")),
     person("James", "Wade", , "github@jameshwade.com", role = c("aut", "cre", "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # gptstudio (development version)
 
+## Bug fixes
+
+- Fixed a bug that prevented the "Spelling and Grammar" and the "Comment your code" addins to actually insert text in source. Fix #101
+
 # gptstudio 0.2.0
 
 ## Translations

--- a/R/gpt_queries.R
+++ b/R/gpt_queries.R
@@ -43,17 +43,17 @@ gpt_edit <- function(model,
     openai_api_key = openai_api_key
   )
 
-  cli::cat_print(edit)
+  # cli::cat_print(edit) # print debugging
 
   if (append_text) {
-    improved_text <- c(selection$value, edit$choices$text)
+    improved_text <- c(selection$value, edit$choices[[1]]$text)
     inform("Appending text from GPT...")
   } else {
-    improved_text <- edit$choices$text
+    improved_text <- edit$choices[[1]]$text
     inform("Inserting text from GPT...")
   }
 
-  cli_text("{improved_text}")
+  # cli_text("{improved_text}") # print debugging
 
   insert_text(improved_text)
 }

--- a/tests/testthat/test-gpt_queries.R
+++ b/tests/testthat/test-gpt_queries.R
@@ -11,7 +11,11 @@ test_that("gpt_edit can replace and append text", {
   mockr::local_mock(
     openai_create_edit =
       function(model, input, instruction, temperature, openai_api_key) {
-        list(choices = data.frame(text = "here are edits openai returns"))
+        list(
+          choices = list(
+            list(text = "here are edits openai returns")
+          )
+        )
       }
   )
   mockr::local_mock(check_api = function() TRUE)


### PR DESCRIPTION
- Fixed a bug that prevented the "Spelling and Grammar" and the "Comment your code" addins to actually insert text in source. Fix #101