### PR TITLE
Patch: Compatibility issues

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@ _\.new\.png$
 ^CRAN-SUBMISSION$
 diagram.svg
 ^revdep$
+dev/

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,6 +23,9 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: 'oldrel-2'}
+          - {os: ubuntu-latest,   r: 'oldrel-3'}
+          - {os: ubuntu-latest,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     rstudioapi (>= 0.12),
     shiny,
     shiny.i18n,
-    stringr,
+    stringr (>= 1.5.0),
     utils
 Suggests: 
     mockr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## Bug fixes
 
-- Fixed a bug that prevented the "Spelling and Grammar" and the "Comment your code" addins to actually insert text in source. Fix #101
+- Fixed a bug that prevented the "Spelling and Grammar" and the "Comment your code" addins to actually insert text in source. Fixes #101
+- Fixed a bug that prevented installation when `{stringr}` was previously installed with a version lower than 1.5.0 . Fixes #110
+- Fixed a bug that prevented installation on versions of R previous to 4.1. Fixes #114, closes #115
 
 ## Model selection
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 - Fixed a bug that prevented installation when `{stringr}` was previously installed with a version lower than 1.5.0 . Fixes #110
 - Fixed a bug that prevented installation on versions of R previous to 4.1. Fixes #114, closes #115
 
+## Notes
+
+- We now use github actions to check on more R versions in ubuntu. At the time of writing, gptstudio will start running checks on R versions `3.6.3`, `4.0.5`, `4.1.3`, `4.2.3`, `4.3.1` (current), and the development version. This should ensure that users can install the package in all those versions. Users can still try and maybe achieve installing on older versions, but we won't actively check compatibility of new features on them.
+
 ## Model selection
 
 - The ChatGPT addin now comes with an integrated model selection feature. This allows users to choose any chat completion model that matches to either `gpt-3.5` or `gpt-4` in the model name. The default model is `gpt-3.5-turbo`, which can be customized via the `gptstudio.chat_model` option.

--- a/R/StreamHandler.R
+++ b/R/StreamHandler.R
@@ -73,7 +73,7 @@ StreamHandler <- R6::R6Class(
         stringr::str_remove("^data: ") %>% # handle first element
         stringr::str_remove("(\n\ndata: \\[DONE\\])?\n\n$") %>% # handle last element
         stringr::str_split_1("\n\ndata: ") %>%
-        purrr::map(\(x) jsonlite::fromJSON(x, simplifyVector = FALSE))
+        purrr::map(~ jsonlite::fromJSON(.x, simplifyVector = FALSE))
     },
     # Reduces the chuks into just the message content.
     convert_chunks_into_response_str = function() {
@@ -148,7 +148,7 @@ stream_chat_completion <-
     # Make the streaming request using curl_fetch_stream()
     curl::curl_fetch_stream(
       url = url,
-      fun = \(x) {
+      fun = function(x) {
         element <- rawToChar(x)
         element_callback(element) # Do whatever element_callback does
       },

--- a/R/check_api.R
+++ b/R/check_api.R
@@ -132,7 +132,7 @@ check_api <- function() {
 
 simple_api_check <- function(api_key = Sys.getenv("OPENAI_API_KEY")) {
   request_base(task = "models", token = api_key) %>%
-    httr2::req_error(is_error = \(resp) FALSE) %>%
+    httr2::req_error(is_error = function(resp) FALSE) %>%
     httr2::req_perform() %>%
     httr2::resp_status()
 }

--- a/R/openai_api_calls.R
+++ b/R/openai_api_calls.R
@@ -170,7 +170,7 @@ query_openai_api <- function(task, request_body, openai_api_key = Sys.getenv("OP
   response <- request_base(task, token = openai_api_key) %>%
     httr2::req_body_json(data = request_body) %>%
     httr2::req_retry(max_tries = 3) %>%
-    httr2::req_error(is_error = \(resp) FALSE) %>%
+    httr2::req_error(is_error = function(resp) FALSE) %>%
     httr2::req_perform()
 
   # error handling

--- a/R/welcomeMessage.R
+++ b/R/welcomeMessage.R
@@ -95,7 +95,7 @@ chat_message_default <- function(translator = create_translator()) {
     "Welcome to the R community! I'm your virtual assistant, and I'm here to support you every step of the way.",
     "Hi there! I'm your personal R virtual assistant, and I'm committed to helping you achieve your coding goals."
   ) %>%
-    purrr::map_chr(\(x) translator$t(x))
+    purrr::map_chr(~ translator$t(.x))
 
   paperplane <- fontawesome::fa("fas fa-paper-plane") %>% as.character()
   eraser <- fontawesome::fa("eraser")
@@ -107,7 +107,7 @@ chat_message_default <- function(translator = create_translator()) {
     "- Clear the current chat history ({eraser})\n",
     "- Change the settings ({gear})\n"
   ) %>%
-    purrr::map_chr(\(x) translator$t(x)) %>%
+    purrr::map_chr(~ translator$t(.x)) %>%
     glue::glue_collapse() %>%
     glue::glue()
 

--- a/dev/config_attachment.yaml
+++ b/dev/config_attachment.yaml
@@ -1,0 +1,12 @@
+path.n: NAMESPACE
+path.d: DESCRIPTION
+dir.r: R
+dir.v: vignettes
+dir.t: tests
+extra.suggests: ~
+pkg_ignore: ~
+document: yes
+normalize: yes
+inside_rmd: no
+must.exist: yes
+check_if_suggests_is_installed: yes

--- a/tests/testthat/test-gpt_queries.R
+++ b/tests/testthat/test-gpt_queries.R
@@ -1,6 +1,6 @@
 mockr::local_mock(
   get_selection = function() {
-    data.frame(value = "here is some selected text")
+    data.frame(value = "here is some selected text", stringsAsFactors = FALSE)
   }
 )
 
@@ -49,7 +49,7 @@ test_that("gpt_create can replace & append text", {
     openai_create_completion =
       function(model, prompt, temperature, max_tokens,
                openai_api_key) {
-        list(choices = data.frame(text = "here are completions openai returns"))
+        list(choices = data.frame(text = "here are completions openai returns", stringsAsFactors = FALSE))
       }
   )
   mockr::local_mock(check_api = function() TRUE)


### PR DESCRIPTION
## Bug fixes 

- Fixed a bug that prevented installation when `{stringr}` was previously installed with a version lower than 1.5.0 . Fixes #110
- Fixed a bug that prevented installation on versions of R previous to 4.1. Fixes #114, closes #115

## Notes

- We now use github actions to check on more R versions in ubuntu. At the time of writing, gptstudio will start running checks on R versions `3.6.3`, `4.0.5`, `4.1.3`, `4.2.3`, `4.3.1` (current), and the development version. This should ensure that users can install the package in all those versions. Users can still try and maybe achieve installing on older versions, but we won't actively check compatibility of new features on them.