### PR TITLE
Read the docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
     R6,
     rlang,
     rstudioapi (>= 0.12),
+    rvest,
     shiny,
     shiny.i18n,
     stringr (>= 1.5.0),

--- a/R/api_perform_request.R
+++ b/R/api_perform_request.R
@@ -26,8 +26,6 @@ gptstudio_request_perform.gptstudio_request_openai <- function(skeleton, shinySe
 
   # Translate request
 
-  # messages <- skeleton$history
-
   skeleton$history <- chat_history_append(
     history = skeleton$history,
     role = "user",
@@ -35,18 +33,8 @@ gptstudio_request_perform.gptstudio_request_openai <- function(skeleton, shinySe
     content = skeleton$prompt
   )
 
-  docs <- read_docs(skeleton$prompt)
-
-  if (!is.null(docs)) {
-    purrr::walk(docs, ~{
-      if (is.null(.x$inner_text)) return(NULL)
-      skeleton$history <<- chat_history_append(
-        history = skeleton$history,
-        role = "user",
-        content = docs_to_message(.x),
-        name = "docs"
-      )
-    })
+  if (getOption("gptstudio.read_docs")) {
+    skeleton$history <- add_docs_messages_to_history(skeleton$history)
   }
 
   body <- list(

--- a/R/api_perform_request.R
+++ b/R/api_perform_request.R
@@ -35,19 +35,19 @@ gptstudio_request_perform.gptstudio_request_openai <- function(skeleton, shinySe
     content = skeleton$prompt
   )
 
-  # docs <- read_docs(skeleton$prompt)
-  #
-  # if (!is.null(docs)) {
-  #   purrr::walk(docs, ~{
-  #     if (is.null(.x$inner_text)) return(NULL)
-  #     messages <<- chat_history_append(
-  #       history = messages,
-  #       role = "user",
-  #       content = docs_to_message(.x$inner_text),
-  #       name = "docs"
-  #     )
-  #   })
-  # }
+  docs <- read_docs(skeleton$prompt)
+
+  if (!is.null(docs)) {
+    purrr::walk(docs, ~{
+      if (is.null(.x$inner_text)) return(NULL)
+      skeleton$history <<- chat_history_append(
+        history = skeleton$history,
+        role = "user",
+        content = docs_to_message(.x),
+        name = "docs"
+      )
+    })
+  }
 
   cli::cli_h3("Messages")
   str(skeleton$history)

--- a/R/api_perform_request.R
+++ b/R/api_perform_request.R
@@ -49,9 +49,6 @@ gptstudio_request_perform.gptstudio_request_openai <- function(skeleton, shinySe
     })
   }
 
-  cli::cli_h3("Messages")
-  str(skeleton$history)
-
   body <- list(
     "model"      = skeleton$model,
     "stream"     = skeleton$stream,
@@ -98,10 +95,11 @@ gptstudio_request_perform.gptstudio_request_openai <- function(skeleton, shinySe
 
     response <- stream_handler$current_value
   } else {
-    response <- request %>%
+    response_json <- request %>%
       httr2::req_perform() %>%
-      httr2::resp_body_json() %>%
-      {.$choices[[1]]$message$content}
+      httr2::resp_body_json()
+
+    response <- response_json$choices[[1]]$message$content
   }
   # return value
   structure(

--- a/R/api_process_response.R
+++ b/R/api_process_response.R
@@ -21,21 +21,14 @@ gptstudio_response_process <- function(skeleton, ...) {
 #' @export
 gptstudio_response_process.gptstudio_response_openai <-
   function(skeleton, ...) {
-    response <- skeleton$response
+    last_response <- skeleton$response
     skeleton <- skeleton$skeleton
 
-    if (skeleton$stream == TRUE) {
-      last_response = response
-    } else {
-      last_response <- response$choices[[1]]$message$content
-    }
-
-    new_history <- c(
-      skeleton$history,
-      list(
-        list(role = "user", content = skeleton$prompt),
-        list(role = "assistant", content = last_response)
-      )
+    new_history <- chat_history_append(
+      history = skeleton$history,
+      role = "assistant",
+      name = "assistant",
+      content = last_response
     )
 
     skeleton$history <- new_history

--- a/R/api_skeletons.R
+++ b/R/api_skeletons.R
@@ -25,7 +25,7 @@ validate_skeleton <- function(url, api_key, model, prompt, history, stream) {
     msg = "API key is not valid"
   )
   assert_that(
-    rlang::is_scalar_character(model),
+    rlang::is_scalar_character(model) && model != "",
     msg = "Model name is not a valid character scalar"
   )
   assert_that(

--- a/R/app_chat_style.R
+++ b/R/app_chat_style.R
@@ -46,6 +46,13 @@ style_chat_message <- function(message,
                            "assistant" = "justify-content-start"
   )
 
+
+  if (!is.null(message$name) && message$name == "docs") {
+    message_content <- render_docs_message_content(message$content)
+  } else {
+    message_content <- shiny::markdown(message$content)
+  }
+
   htmltools::div(
     class = glue("row m-0 p-0 {position_class}"),
     htmltools::tags$div(
@@ -58,7 +65,7 @@ style_chat_message <- function(message,
       htmltools::tags$div(
         class = glue("{message$role}-message-wrapper"),
         htmltools::tagList(
-          shiny::markdown(message$content)
+          message_content
         )
       )
     )
@@ -91,6 +98,27 @@ create_ide_matching_colors <- function(role,
   list(
     bg_color = bg_colors[[role]],
     fg_color = ide_colors$fg
+  )
+}
+
+render_docs_message_content <- function(x) {
+  docs_info <- x %>%
+    stringr::str_extract("gptstudio-metadata-docs-start.*gptstudio-metadata-docs-end") %>%
+    stringr::str_remove("gptstudio-metadata-docs-start-") %>%
+    stringr::str_remove("-gptstudio-metadata-docs-end") %>%
+    stringr::str_split_1(pattern = "-")
+
+  pkg_ref <- docs_info[1]
+  topic <- docs_info[2]
+
+  message_content <- x %>%
+    stringr::str_remove("gptstudio-metadata-docs-start.*gptstudio-metadata-docs-end") %>%
+    shiny::markdown()
+
+  message_content <- tags$div(
+    "R documentation:",
+    tags$code(glue::glue("{pkg_ref}::{topic}")) %>%
+      bslib::tooltip(message_content)
   )
 }
 

--- a/R/app_chat_style.R
+++ b/R/app_chat_style.R
@@ -150,8 +150,13 @@ text_area_input_wrapper <-
 #'
 #' @return list of chat messages
 #'
-chat_history_append <- function(history, role, content) {
-  c(history, list(
-    list(role = role, content = content)
-  ))
+chat_history_append <- function(history, role, content, name = NULL) {
+  new_message <- list(
+    role = role,
+    content = content,
+    name = name
+  ) %>%
+    purrr::compact()
+
+  c(history, list(new_message))
 }

--- a/R/app_chat_style.R
+++ b/R/app_chat_style.R
@@ -175,6 +175,7 @@ text_area_input_wrapper <-
 #' @param role Author of the message. One of `c("user", "assistant")`
 #' @param content Content of the message. If it is from the user most probably
 #' comes from an interactive input.
+#' @param name Name for the author of the message. Currently used to support rendering of help pages
 #'
 #' @return list of chat messages
 #'

--- a/R/app_config.R
+++ b/R/app_config.R
@@ -5,7 +5,8 @@ save_user_config <- function(code_style,
                              service,
                              model,
                              custom_prompt,
-                             stream) {
+                             stream,
+                             read_docs) {
   if (is.null(custom_prompt)) custom_prompt <- ""
   config <-
     data.frame(
@@ -16,7 +17,8 @@ save_user_config <- function(code_style,
       service,
       model,
       custom_prompt,
-      stream
+      stream,
+      read_docs
     )
   user_config_path <- tools::R_user_dir("gptstudio", which = "config")
   user_config <- file.path(user_config_path, "config.yml")
@@ -38,7 +40,9 @@ set_user_options <- function(config) {
     gptstudio.service       = config$service,
     gptstudio.model         = config$model,
     gptstudio.custom_prompt = config$custom_prompt,
-    gptstudio.stream        = config$stream
+    gptstudio.stream        = config$stream,
+    # added in v.3.1+ dev version
+    gptstudio.read_docs     = config$read_docs
   )
   options(op_gptstudio)
   invisible()

--- a/R/mod_settings.R
+++ b/R/mod_settings.R
@@ -55,7 +55,7 @@ mod_settings_ui <- function(id, translator = create_translator()) {
       selectInput(
         inputId = ns("model"),
         label = translator$t("Chat Model"),
-        choices = NULL,
+        choices = getOption("gptstudio.model"),
         width = "200px",
         selected = getOption("gptstudio.model")
       ),

--- a/R/mod_settings.R
+++ b/R/mod_settings.R
@@ -38,7 +38,13 @@ mod_settings_ui <- function(id, translator = create_translator()) {
       textAreaInput(
         inputId = ns("custom_prompt"),
         label = translator$t("Custom Prompt"),
-        value = getOption("gptstudio.custom_prompt"))
+        value = getOption("gptstudio.custom_prompt")
+      ),
+      bslib::input_switch(
+        id = ns("read_docs"),
+        label = "Read help pages",
+        value = getOption("gptstudio.read_docs")
+      )
     ),
 
     bslib::accordion_panel(
@@ -192,7 +198,8 @@ mod_settings_server <- function(id) {
         service = input$service,
         model = input$model,
         custom_prompt = input$custom_prompt,
-        stream = input$stream
+        stream = input$stream,
+        read_docs = input$read_docs
       )
 
       rv$modify_session_settings <- rv$modify_session_settings + 1L

--- a/R/mod_settings.R
+++ b/R/mod_settings.R
@@ -5,6 +5,16 @@ mod_settings_ui <- function(id, translator = create_translator()) {
     stringr::str_remove(pattern = "gptstudio_request_perform.gptstudio_request_") %>%
     purrr::discard(~ .x == "gptstudio_request_perform.default")
 
+  read_docs_label <- tags$span(
+    "Read R help pages",
+    bslib::tooltip(
+      shiny::icon("info-circle"),
+      "Add help pages of 'package::object' matches for context.
+      Potentially expensive.
+      Save as default to effectively change"
+    )
+  )
+
   preferences <- bslib::accordion(
     open = FALSE,
     multiple = FALSE,
@@ -42,7 +52,7 @@ mod_settings_ui <- function(id, translator = create_translator()) {
       ),
       bslib::input_switch(
         id = ns("read_docs"),
-        label = "Read help pages",
+        label = read_docs_label,
         value = getOption("gptstudio.read_docs")
       )
     ),

--- a/R/openai_streaming.R
+++ b/R/openai_streaming.R
@@ -18,7 +18,7 @@ stream_chat_completion <-
            model = "gpt-3.5-turbo",
            openai_api_key = Sys.getenv("OPENAI_API_KEY")) {
     # Set the API endpoint URL
-    url <- "https://api.openai.com/v1/chat/completions"
+    url <- paste0(getOption("gptstudio.openai_url"), "/chat/completions")
 
     # Set the request headers
     headers <- list(

--- a/R/openai_streaming.R
+++ b/R/openai_streaming.R
@@ -3,8 +3,7 @@
 #' `stream_chat_completion` sends the prepared chat completion request to the
 #' OpenAI API and retrieves the streamed response.
 #'
-#' @param prompt The user's message or prompt.
-#' @param history A list of previous messages in the conversation (optional).
+#' @param messages A list of messages in the conversation, including the current user prompt (optional).
 #' @param element_callback A callback function to handle each element of the streamed response (optional).
 #' @param model A character string specifying the model to use for chat completion.
 #' The default model is "gpt-3.5-turbo".
@@ -14,8 +13,7 @@
 #' treated accordingly.
 #' @return The same as `curl::curl_fetch_stream`
 stream_chat_completion <-
-  function(prompt,
-           history = NULL,
+  function(messages = NULL,
            element_callback = cat,
            model = "gpt-3.5-turbo",
            openai_api_key = Sys.getenv("OPENAI_API_KEY")) {
@@ -26,12 +24,6 @@ stream_chat_completion <-
     headers <- list(
       "Content-Type" = "application/json",
       "Authorization" = paste0("Bearer ", openai_api_key)
-    )
-
-    messages <- chat_history_append(
-      history = history,
-      role = "user",
-      content = prompt
     )
 
     # Set the request body

--- a/R/read_docs.R
+++ b/R/read_docs.R
@@ -15,7 +15,7 @@ read_docs <- function(user_prompt) {
 
 read_html_docs <- function(pkg_ref, topic_name) {
   # This should output a scalar character
-  file_location <- help(topic = (topic_name), package = (pkg_ref), help_type = "html") %>%
+  file_location <- utils::help(topic = (topic_name), package = (pkg_ref), help_type = "html") %>%
     as.character()
 
   if (rlang::is_empty(file_location)) return()
@@ -37,7 +37,7 @@ read_html_docs <- function(pkg_ref, topic_name) {
 
   env[[topic_name]] %>%
     tools::Rd2HTML() %>%
-    capture.output() %>%
+    utils::capture.output() %>%
     paste0(collapse = "\n") %>%
     rvest::read_html()
 }

--- a/R/read_docs.R
+++ b/R/read_docs.R
@@ -117,3 +117,13 @@ locate_double_colon_calls <- function(x) {
     stringr::str_split("::") %>%
     purrr::map(~list(pkg_ref = .x[1], topic = .x[2]))
 }
+
+docs_to_message <- function(x) {
+  glue::glue(
+    "# {x$title}
+
+    ## Description
+
+    {x$description}"
+  )
+}

--- a/R/read_docs.R
+++ b/R/read_docs.R
@@ -74,6 +74,7 @@ docs_get_inner_text <- function(x) {
     usage = sections[["Usage"]], # all
     arguments = sections[["Arguments"]], # only functions
     examples = sections[["Examples"]], # only functions
+    value = sections[["Value"]], # only functions
     format = sections[["Format"]] # only data
   )
 

--- a/R/read_docs.R
+++ b/R/read_docs.R
@@ -132,3 +132,21 @@ docs_to_message <- function(x) {
 
   glue::glue("gptstudio-metadata-docs-start-{x$pkg_ref}-{x$topic}-gptstudio-metadata-docs-end{inner_content}")
 }
+
+add_docs_messages_to_history <- function(skeleton_history) {
+  last_user_message <- skeleton_history[[length(skeleton_history)]]$content
+  docs <- read_docs(last_user_message)
+
+  if(is.null(docs)) return(skeleton_history)
+
+  purrr::walk(docs, ~{
+    if (is.null(.x$inner_text)) return(NULL)
+    skeleton_history <<- chat_history_append(
+      history = skeleton_history,
+      role = "user",
+      content = docs_to_message(.x),
+      name = "docs"
+    )
+  })
+  skeleton_history
+}

--- a/R/read_docs.R
+++ b/R/read_docs.R
@@ -119,11 +119,16 @@ locate_double_colon_calls <- function(x) {
 }
 
 docs_to_message <- function(x) {
-  glue::glue(
-    "# {x$title}
+  x %>%
+    purrr::compact() %>%
+    purrr::imap_chr(function(.x, i) {
+      if (i == "title") return(glue::glue("# {.x}"))
 
-    ## Description
+      section_title <- stringr::str_to_title(i)
+      section_body <- if(i=="examples") glue::glue("<pre>{.x}</pre>") else .x
+      glue::glue("## {section_title}\n\n{section_body}")
+    }) %>%
+    paste0(collapse = "\n\n")
 
-    {x$description}"
-  )
+
 }

--- a/R/read_docs.R
+++ b/R/read_docs.R
@@ -1,7 +1,7 @@
 read_docs <- function(user_prompt) {
   calls <- locate_double_colon_calls(user_prompt)
 
-  if (length(calls) == 0) return(list())
+  if (length(calls) == 0) return()
 
   documentation <- calls %>%
     purrr::map(function(x) read_html_docs(x$pkg_ref, x$topic))
@@ -18,7 +18,7 @@ read_html_docs <- function(pkg_ref, topic_name) {
   file_location <- help(topic = (topic_name), package = (pkg_ref), help_type = "html") %>%
     as.character()
 
-  if (rlang::is_empty(file_location)) return(NULL)
+  if (rlang::is_empty(file_location)) return()
 
   env <- rlang::new_environment()
 

--- a/R/read_docs.R
+++ b/R/read_docs.R
@@ -1,0 +1,118 @@
+read_docs <- function(user_prompt) {
+  calls <- locate_double_colon_calls(user_prompt)
+
+  if (length(calls) == 0) return(list())
+
+  documentation <- calls %>%
+    purrr::map(function(x) read_html_docs(x$pkg_ref, x$topic))
+
+  inner_text <- documentation %>%
+    purrr::map(docs_get_inner_text)
+
+  purrr::map2(calls, inner_text, ~c(.x, list(inner_text = .y)))
+}
+
+
+read_html_docs <- function(pkg_ref, topic_name) {
+  # This should output a scalar character
+  file_location <- help(topic = (topic_name), package = (pkg_ref), help_type = "html") %>%
+    as.character()
+
+  if (rlang::is_empty(file_location)) return(NULL)
+
+  env <- rlang::new_environment()
+
+  file_location %>%
+    get_help_file_path() %>%
+    lazyLoad(envir = env)
+
+  #################
+  # This is an alternative way to read the help but
+  # requires writing to disk first
+
+  # tmp <- tempfile(fileext = ".html")
+  # tools::Rd2HTML(Rd = env[[topic_name]], out = tmp)
+  # rvest::read_html(tmp)
+  ##################
+
+  env[[topic_name]] %>%
+    tools::Rd2HTML() %>%
+    capture.output() %>%
+    paste0(collapse = "\n") %>%
+    rvest::read_html()
+}
+
+get_help_file_path <- function (file) {
+  path <- dirname(file)
+  dirpath <- dirname(path)
+  if (!file.exists(dirpath))
+    stop(gettextf("invalid %s argument", sQuote("file")),
+         domain = NA)
+  pkgname <- basename(dirpath)
+  file.path(path, pkgname)
+}
+
+
+docs_get_inner_text <- function(x) {
+  if(is.null(x)) return(NULL)
+
+  main_container <- x %>%
+    rvest::html_element("body") %>%
+    rvest::html_element(".container")
+
+  title <- main_container %>%
+    rvest::html_element("h2") %>%
+    rvest::html_text()
+
+  sections <- main_container %>%
+    rvest::html_children() %>%
+    docs_get_sections()
+
+  list(
+    title = title, # all
+    description = sections[["Description"]], # all
+    usage = sections[["Usage"]], # all
+    arguments = sections[["Arguments"]], # only functions
+    examples = sections[["Examples"]], # only functions
+    format = sections[["Format"]] # only data
+  )
+
+}
+
+docs_get_sections <- function(children) {
+  h3_locations <- children %>%
+    purrr::map_lgl(~rvest::html_name(.x) == "h3") %>%
+    which()
+
+  inner_texts <- children %>%
+    purrr::map_chr(rvest::html_text2)
+
+  section_ranges <- h3_locations %>%
+    purrr::imap(function(.x, i){
+      begin <- h3_locations[i] + 1
+      end <- integer()
+      item_is_the_last_h3 <- i == length(h3_locations)
+
+      if (item_is_the_last_h3) {
+        end <- length(children)
+      } else {
+        end <- h3_locations[i+1] - 1
+      }
+
+      list(begin = begin, end = end)
+    })
+
+  section_ranges %>%
+    purrr::map(~inner_texts[.x$begin:.x$end] %>% paste0(collapse = "\n\n")) %>%
+    purrr::set_names(inner_texts[h3_locations])
+}
+
+locate_double_colon_calls <- function(x) {
+  all_matches <- x %>%
+    stringr::str_extract_all("`?\\b\\w+::(\\w|\\.)+\\b`?")
+
+  all_matches[[1]] %>%
+    stringr::str_remove_all("`") %>%
+    stringr::str_split("::") %>%
+    purrr::map(~list(pkg_ref = .x[1], topic = .x[2]))
+}

--- a/R/read_docs.R
+++ b/R/read_docs.R
@@ -73,9 +73,9 @@ docs_get_inner_text <- function(x) {
     description = sections[["Description"]], # all
     usage = sections[["Usage"]], # all
     arguments = sections[["Arguments"]], # only functions
-    examples = sections[["Examples"]], # only functions
+    format = sections[["Format"]], # only data
     value = sections[["Value"]], # only functions
-    format = sections[["Format"]] # only data
+    examples = sections[["Examples"]] # only functions
   )
 
 }
@@ -119,7 +119,7 @@ locate_double_colon_calls <- function(x) {
 }
 
 docs_to_message <- function(x) {
-  x %>%
+  inner_content <- x$inner_text %>%
     purrr::compact() %>%
     purrr::imap_chr(function(.x, i) {
       if (i == "title") return(glue::glue("# {.x}"))
@@ -130,5 +130,5 @@ docs_to_message <- function(x) {
     }) %>%
     paste0(collapse = "\n\n")
 
-
+  glue::glue("gptstudio-metadata-docs-start-{x$pkg_ref}-{x$topic}-gptstudio-metadata-docs-end{inner_content}")
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,7 +23,10 @@
     gptstudio.service       = config$service,
     gptstudio.model         = config$model,
     gptstudio.custom_prompt = config$custom_prompt,
-    gptstudio.stream        = config$stream
+    gptstudio.stream        = config$stream,
+    # options added after v3.0 will need a safe check because the user's
+    # config file might not have values for new features
+    gptstudio.read_docs     = config$read_docs %||% FALSE
   )
 
   toset <- !(names(op_gptstudio) %in% names(op))

--- a/inst/rstudio/config.yml
+++ b/inst/rstudio/config.yml
@@ -6,3 +6,4 @@ service: "openai"
 model: "gpt-3.5-turbo"
 custom_prompt: "You are a helpful assistant."
 stream: true
+read_docs: false

--- a/man/chat_history_append.Rd
+++ b/man/chat_history_append.Rd
@@ -4,7 +4,7 @@
 \alias{chat_history_append}
 \title{Append to chat history}
 \usage{
-chat_history_append(history, role, content)
+chat_history_append(history, role, content, name = NULL)
 }
 \arguments{
 \item{history}{List containing previous responses.}
@@ -13,6 +13,8 @@ chat_history_append(history, role, content)
 
 \item{content}{Content of the message. If it is from the user most probably
 comes from an interactive input.}
+
+\item{name}{Name for the author of the message. Currently used to support rendering of help pages}
 }
 \value{
 list of chat messages

--- a/man/stream_chat_completion.Rd
+++ b/man/stream_chat_completion.Rd
@@ -5,17 +5,14 @@
 \title{Stream Chat Completion}
 \usage{
 stream_chat_completion(
-  prompt,
-  history = NULL,
+  messages = NULL,
   element_callback = cat,
   model = "gpt-3.5-turbo",
   openai_api_key = Sys.getenv("OPENAI_API_KEY")
 )
 }
 \arguments{
-\item{prompt}{The user's message or prompt.}
-
-\item{history}{A list of previous messages in the conversation (optional).}
+\item{messages}{A list of messages in the conversation, including the current user prompt (optional).}
 
 \item{element_callback}{A callback function to handle each element of the streamed response (optional).}
 

--- a/tests/testthat/test-read-docs.R
+++ b/tests/testthat/test-read-docs.R
@@ -1,0 +1,70 @@
+test_that("read_docs() returns NULL when there is no namespace::object match in prompt" , {
+  read_docs("Text with no match for regular expression") %>%
+    expect_null()
+})
+
+test_that("read_docs() matches all expected case types", {
+  # meaning snake_case, camelCase, etc
+  read_docs("tidyr::pivot_longer") %>% expect_type("list")
+  read_docs("base::as.data.frame") %>% expect_type("list")
+  read_docs("base::data.frame") %>% expect_type("list")
+  read_docs("base::isTrue") %>% expect_type("list")
+  read_docs("ggplot2::geom_text") %>% expect_type("list")
+})
+
+test_that("read_docs() works in operators", {
+  skip("To be implemented: work in operators")
+  read_docs("magrittr::%>%") %>% expect_type("list")
+})
+
+test_that("read_docs() works in when functions share docs", {
+  skip("To be implemented: functions share docs")
+  read_docs("stringr::str_split_1") %>% expect_type("list")
+})
+
+test_that("read_docs() returns expected lengths and types", {
+  test_prompt_single <- "Check dplyr::filter for info"
+  test_prompt_multiple <- "Check tidyr::nest and ggplot2::geom_text for examples"
+
+  read_docs(test_prompt_single) %>%
+    expect_type("list") %>%
+    expect_length(1L)
+
+  read_docs(test_prompt_multiple) %>%
+    expect_type("list") %>%
+    expect_length(2L)
+})
+
+test_that("read_docs() returns expected structure when documentation exists", {
+  test_prompt <- "See tibble::tibble for more" %>%
+    read_docs()
+
+  test_prompt %>%
+    expect_type("list") %>%
+    expect_length(1L)
+
+  test_prompt %>%
+    purrr::pluck(1L) %>%
+    expect_named(c("pkg_ref", "topic", "inner_text"))
+
+  test_prompt %>%
+    purrr::pluck(1L, "inner_text") %>%
+    expect_type("list")
+})
+
+test_that("read_docs() returns expected structure when no documentation found", {
+  test_prompt <- "See base::tibble for more" %>%
+    read_docs()
+
+  test_prompt %>%
+    expect_type("list") %>%
+    expect_length(1L)
+
+  test_prompt %>%
+    purrr::pluck(1L) %>%
+    expect_named(c("pkg_ref", "topic", "inner_text"))
+
+  test_prompt %>%
+    purrr::pluck(1L, "inner_text") %>%
+    expect_null()
+})

--- a/tests/testthat/test-read-docs.R
+++ b/tests/testthat/test-read-docs.R
@@ -5,11 +5,11 @@ test_that("read_docs() returns NULL when there is no namespace::object match in 
 
 test_that("read_docs() matches all expected case types", {
   # meaning snake_case, camelCase, etc
-  read_docs("tidyr::pivot_longer") %>% expect_type("list")
+  read_docs("purrr::as_vector") %>% expect_type("list")
   read_docs("base::as.data.frame") %>% expect_type("list")
   read_docs("base::data.frame") %>% expect_type("list")
   read_docs("base::isTrue") %>% expect_type("list")
-  read_docs("ggplot2::geom_text") %>% expect_type("list")
+  read_docs("stringr::str_view") %>% expect_type("list")
 })
 
 test_that("read_docs() works in operators", {
@@ -24,14 +24,16 @@ test_that("read_docs() works when functions share docs", {
 
   # Right now this errors for some reason
   read_docs("stringr::str_split_1") %>% expect_type("list")
+  read_docs("htmltools::tags") %>% expect_type("list")
+  read_docs("rlang::is_atomic") %>% expect_type("list")
 
   # but this works ?
   read_docs("stringr::str_split") %>% expect_type("list")
 })
 
 test_that("read_docs() returns expected lengths and types", {
-  test_prompt_single <- "Check dplyr::filter for info"
-  test_prompt_multiple <- "Check tidyr::nest and ggplot2::geom_text for examples"
+  test_prompt_single <- "Check purrr::map for info"
+  test_prompt_multiple <- "Check rlang::abort and cli::cli for examples"
 
   read_docs(test_prompt_single) %>%
     expect_type("list") %>%
@@ -43,7 +45,7 @@ test_that("read_docs() returns expected lengths and types", {
 })
 
 test_that("read_docs() returns expected structure when documentation exists", {
-  test_prompt <- "See tibble::tibble for more" %>%
+  test_prompt <- "See glue::glue for more" %>%
     read_docs()
 
   test_prompt %>%

--- a/tests/testthat/test-read-docs.R
+++ b/tests/testthat/test-read-docs.R
@@ -14,12 +14,19 @@ test_that("read_docs() matches all expected case types", {
 
 test_that("read_docs() works in operators", {
   skip("To be implemented: work in operators")
+
+  # Right now this returns NULL, as in no match
   read_docs("magrittr::%>%") %>% expect_type("list")
 })
 
-test_that("read_docs() works in when functions share docs", {
+test_that("read_docs() works when functions share docs", {
   skip("To be implemented: functions share docs")
+
+  # Right now this errors for some reason
   read_docs("stringr::str_split_1") %>% expect_type("list")
+
+  # but this works ?
+  read_docs("stringr::str_split") %>% expect_type("list")
 })
 
 test_that("read_docs() returns expected lengths and types", {


### PR DESCRIPTION
This is a work in progress to close #138. 

We will look for a match in the form "namespace::object" in the user prompt. There are three scenarios:

1. There is no match: In this case, we return NULL
2. There is a match of the form "namespace::object" in the use prompt, but it doesn't match any documentation (e.g. "base::as_tibble", there is no `as_tibble` object in the base package). We return `list(package = "base", topic = "as_tibble",  inner_text = NULL)`
3. There is a match of the form "namespace::object" and there is documentation for it. We return the same as before, but `inner_text` becomes a list with elements `title`, `description`, `usage`, `arguments`, `value`, `examples`, and `format`.

`read_docs()` returns NULL (scenario 1) or a list of elements following the structure of scenarios 2 and 3. `read_docs()` is done.

I'm thinking on how to pass this to the chat history in the backend and the UI. I would prefer to not just paste the docs in the user message because it could make the conversation hard to follow.

We should also add a setting to turn on/off reading the docs, as it will without a doubt increase the "tokens" per request.