### PR TITLE
Avoid evaluating R code in "in source" instructions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@ Cohere is now available as another service. The current version includes the fol
 - Updated anthropic API calls to use new messages endpoint.
 - Fixed a bug in Anthropic chats to now include history.
 - OpenAI stream no longer hangs with error "Argument has length 0". #199
+- In source calls no longer attempt to evaluate R code. #203
 
 ### Quality of Life Improvements and Documentation
 

--- a/R/service-openai_gpt_queries.R
+++ b/R/service-openai_gpt_queries.R
@@ -23,7 +23,7 @@ gptstudio_chat_in_source <- function(task = NULL) {
 
   instructions <- glue::glue("{task}: {selection$value}")
 
-  cli::cli_inform(instructions)
+  cli::cli_inform("{instructions}")
 
   cli::cli_progress_step("Sending query to ChatGPT...",
     msg_done = "ChatGPT responded",


### PR DESCRIPTION
## Related issue

- Closes #203 

## Description of changes

- In source calls no longer attempt to evaluate R code

## For contributors

- [X] I have added the relevant changes to the NEWS.md file
- [X] I have added relevant tests or documentation with my changes

## For reviewers

- [] Changes meet the acceptance criteria of the related issue
- [] The contribution follows style conventions and code of conduct
- [] Branch passes automated testing
- [] I have incremented the package version in the DESCRIPTION file before merging
