### PR TITLE
[feat] add gpt-4o-mini and set as default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gptstudio
 Title: Use Large Language Models Directly in your Development Environment
-Version: 0.4.0.9001
+Version: 0.4.0.9002
 Authors@R: c(
     person("Michel", "Nivard", , "m.g.nivard@vu.nl", role = c("aut", "cph")),
     person("James", "Wade", , "github@jameshwade.com", role = c("aut", "cre", "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Fixed a bug that showed the message "ChatGPT responded" even when other service was being used in "Chat in source" related addins. #213
 - Added claude-3.5-sonnet model from Anthropic.
+- Set gpt-4o-mini as default model for OpenAI. #219
 
 ## gptstudio 0.4.0
 

--- a/R/api_skeletons.R
+++ b/R/api_skeletons.R
@@ -137,7 +137,7 @@ new_gptstudio_request_skeleton_google <- function(
 new_gptstudio_request_skeleton_azure_openai <- function(
     url = "user provided with environmental variables",
     api_key = Sys.getenv("AZURE_OPENAI_KEY"),
-    model = "gpt-3.5-turbo",
+    model = "gpt-4o-mini",
     prompt = "What is a ggplot?",
     history = list(
       list(
@@ -249,7 +249,7 @@ gptstudio_create_skeleton <- function(service = "openai",
                                         )
                                       ),
                                       stream = TRUE,
-                                      model = "gpt-3.5-turbo",
+                                      model = "gpt-4o-mini",
                                       ...) {
   switch(service,
     "openai" = new_gptstudio_request_skeleton_openai(

--- a/R/models.R
+++ b/R/models.R
@@ -41,7 +41,7 @@ list_available_models.openai <- function(service) {
     stringr::str_subset("vision", negate = TRUE) %>%
     sort()
 
-  idx <- which(models == "gpt-3.5-turbo")
+  idx <- which(models == "gpt-4o-mini")
   models <- c(models[idx], models[-idx])
   return(models)
 }

--- a/R/service-openai_streaming.R
+++ b/R/service-openai_streaming.R
@@ -8,7 +8,7 @@
 #' @param element_callback A callback function to handle each element
 #' of the streamed response (optional).
 #' @param model A character string specifying the model to use for chat completion.
-#' The default model is "gpt-3.5-turbo".
+#' The default model is "gpt-4o-mini".
 #' @param openai_api_key A character string of the OpenAI API key.
 #' By default, it is fetched from the "OPENAI_API_KEY" environment variable.
 #' Please note that the OpenAI API key is sensitive information and should be
@@ -17,7 +17,7 @@
 stream_chat_completion <-
   function(messages = NULL,
            element_callback = cat,
-           model = "gpt-3.5-turbo",
+           model = "gpt-4o-mini",
            openai_api_key = Sys.getenv("OPENAI_API_KEY")) {
     # Set the API endpoint URL
     url <- paste0(getOption("gptstudio.openai_url"), "/chat/completions")

--- a/man/gptstudio_create_skeleton.Rd
+++ b/man/gptstudio_create_skeleton.Rd
@@ -9,7 +9,7 @@ gptstudio_create_skeleton(
   prompt = "Name the top 5 packages in R.",
   history = list(list(role = "system", content = "You are an R chat assistant")),
   stream = TRUE,
-  model = "gpt-3.5-turbo",
+  model = "gpt-4o-mini",
   ...
 )
 }

--- a/man/stream_chat_completion.Rd
+++ b/man/stream_chat_completion.Rd
@@ -7,7 +7,7 @@
 stream_chat_completion(
   messages = NULL,
   element_callback = cat,
-  model = "gpt-3.5-turbo",
+  model = "gpt-4o-mini",
   openai_api_key = Sys.getenv("OPENAI_API_KEY")
 )
 }
@@ -19,7 +19,7 @@ including the current user prompt (optional).}
 of the streamed response (optional).}
 
 \item{model}{A character string specifying the model to use for chat completion.
-The default model is "gpt-3.5-turbo".}
+The default model is "gpt-4o-mini".}
 
 \item{openai_api_key}{A character string of the OpenAI API key.
 By default, it is fetched from the "OPENAI_API_KEY" environment variable.

--- a/tests/testthat/test-models.R
+++ b/tests/testthat/test-models.R
@@ -16,10 +16,11 @@ test_that("get_available_models works for openai", {
   service <- "openai"
   models <- get_available_models(service)
   expect_equal(models, c(
+    "gpt-4o-mini",
     "gpt-3.5-turbo", "gpt-3.5-turbo-0125", "gpt-3.5-turbo-1106",
     "gpt-3.5-turbo-16k", "gpt-4", "gpt-4-0125-preview", "gpt-4-0613",
     "gpt-4-1106-preview", "gpt-4-turbo", "gpt-4-turbo-2024-04-09",
-    "gpt-4-turbo-preview", "gpt-4o", "gpt-4o-2024-05-13"
+    "gpt-4-turbo-preview", "gpt-4o", "gpt-4o-2024-05-13", "gpt-4o-mini-2024-07-18"
   ))
 })
 
@@ -73,8 +74,9 @@ test_that("get_available_models works for cohere", {
   service <- "cohere"
   models <- get_available_models(service)
   expect_equal(models, c(
-    "command-r", "command-nightly", "command-r-plus", "c4ai-aya-23",
-    "command-light-nightly", "command", "command-light"
+    "command-r", "command-r-plus", "c4ai-aya-23",
+    "command-light-nightly", "command-nightly",
+    "command", "command-light"
   ))
 })
 


### PR DESCRIPTION
## Related issue

- Closes #219 

## Description of changes

- Update gpt-4o-mini as default model and update test accordingly.

## For contributors

- [x] I have added the relevant changes to the NEWS.md file
- [x] I have added relevant tests or documentation with my changes

## For reviewers

- [] Changes meet the acceptance criteria of the related issue
- [] The contribution follows style conventions and code of conduct
- [] Branch passes automated testing
- [] I have incremented the package version in the DESCRIPTION file before merging
