### PR TITLE
[Bug] Improve token handling, rename api key name, and write tests for Azure OpenAI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gptstudio
 Title: Use Large Language Models Directly in your Development Environment
-Version: 0.4.0.9002
+Version: 0.4.0.9003
 Authors@R: c(
     person("Michel", "Nivard", , "m.g.nivard@vu.nl", role = c("aut", "cph")),
     person("James", "Wade", , "github@jameshwade.com", role = c("aut", "cre", "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - Fixed a bug that showed the message "ChatGPT responded" even when other service was being used in "Chat in source" related addins. #213
 - Added claude-3.5-sonnet model from Anthropic.
 - Set gpt-4o-mini as default model for OpenAI. #219
+- Fixed bugs with Azure OpenAI service. #223
 
 ## gptstudio 0.4.0
 

--- a/R/api_perform_request.R
+++ b/R/api_perform_request.R
@@ -158,15 +158,12 @@ gptstudio_request_perform.gptstudio_request_azure_openai <- function(skeleton, .
     )
   )
 
-  body <- list("messages" = messages)
+  response <- query_api_azure_openai(request_body = messages)
 
-  cat_print(body)
-
-  response <- create_completion_azure_openai(prompt = body)
   structure(
     list(
       skeleton = skeleton,
-      response = response
+      response = response$choices[[1]]$message$content
     ),
     class = "gptstudio_response_azure_openai"
   )

--- a/R/api_process_response.R
+++ b/R/api_process_response.R
@@ -115,11 +115,7 @@ gptstudio_response_process.gptstudio_response_azure_openai <-
     response <- skeleton$response
     skeleton <- skeleton$skeleton
 
-    if (skeleton$stream == TRUE) {
-      last_response <- response
-    } else {
-      last_response <- response$choices[[1]]$message$content
-    }
+    last_response <- response
 
     new_history <- c(
       skeleton$history,

--- a/R/api_skeletons.R
+++ b/R/api_skeletons.R
@@ -137,7 +137,7 @@ new_gptstudio_request_skeleton_google <- function(
 new_gptstudio_request_skeleton_azure_openai <- function(
     url = "user provided with environmental variables",
     api_key = Sys.getenv("AZURE_OPENAI_API_KEY"),
-    model = "gpt-4o-mini",
+    model = "gpt-4o",
     prompt = "What is a ggplot?",
     history = list(
       list(

--- a/R/api_skeletons.R
+++ b/R/api_skeletons.R
@@ -136,7 +136,7 @@ new_gptstudio_request_skeleton_google <- function(
 
 new_gptstudio_request_skeleton_azure_openai <- function(
     url = "user provided with environmental variables",
-    api_key = Sys.getenv("AZURE_OPENAI_KEY"),
+    api_key = Sys.getenv("AZURE_OPENAI_API_KEY"),
     model = "gpt-4o-mini",
     prompt = "What is a ggplot?",
     history = list(

--- a/R/gptstudio-sitrep.R
+++ b/R/gptstudio-sitrep.R
@@ -192,7 +192,7 @@ gptstudio_sitrep <- function(verbose = TRUE) {
     cli::cli_h3("Checking Azure OpenAI API connection")
     check_api_connection_azure_openai(
       service = "Azure OpenAI",
-      api_key = Sys.getenv("AZURE_OPENAI_KEY")
+      api_key = Sys.getenv("AZURE_OPENAI_API_KEY")
     )
     cli::cli_h3("Checking Perplexity API connection")
     check_api_connection_perplexity(

--- a/man/create_completion_azure_openai.Rd
+++ b/man/create_completion_azure_openai.Rd
@@ -9,7 +9,7 @@ create_completion_azure_openai(
   task = Sys.getenv("AZURE_OPENAI_TASK"),
   base_url = Sys.getenv("AZURE_OPENAI_ENDPOINT"),
   deployment_name = Sys.getenv("AZURE_OPENAI_DEPLOYMENT_NAME"),
-  token = Sys.getenv("AZURE_OPENAI_API_KEY"),
+  api_key = Sys.getenv("AZURE_OPENAI_API_KEY"),
   api_version = Sys.getenv("AZURE_OPENAI_API_VERSION")
 )
 }
@@ -28,7 +28,7 @@ OpenAI endpoint from environment variables if not specified.}
 default to the Azure OpenAI deployment name from environment variables if
 not specified.}
 
-\item{token}{a character string for the API key. It will default to the Azure
+\item{api_key}{a character string for the API key. It will default to the Azure
 OpenAI API key from your environment variables if not specified.}
 
 \item{api_version}{a character string for the API version. It will default to

--- a/man/create_completion_azure_openai.Rd
+++ b/man/create_completion_azure_openai.Rd
@@ -9,7 +9,7 @@ create_completion_azure_openai(
   task = Sys.getenv("AZURE_OPENAI_TASK"),
   base_url = Sys.getenv("AZURE_OPENAI_ENDPOINT"),
   deployment_name = Sys.getenv("AZURE_OPENAI_DEPLOYMENT_NAME"),
-  token = Sys.getenv("AZURE_OPENAI_KEY"),
+  token = Sys.getenv("AZURE_OPENAI_API_KEY"),
   api_version = Sys.getenv("AZURE_OPENAI_API_VERSION")
 )
 }

--- a/tests/testthat/_snaps/models.md
+++ b/tests/testthat/_snaps/models.md
@@ -1,0 +1,37 @@
+# get_available_models works for openai
+
+    Code
+      models
+    Output
+       [1] "gpt-4o-mini"            "gpt-3.5-turbo"          "gpt-3.5-turbo-0125"    
+       [4] "gpt-3.5-turbo-1106"     "gpt-3.5-turbo-16k"      "gpt-4"                 
+       [7] "gpt-4-0125-preview"     "gpt-4-0613"             "gpt-4-1106-preview"    
+      [10] "gpt-4-turbo"            "gpt-4-turbo-2024-04-09" "gpt-4-turbo-preview"   
+      [13] "gpt-4o"                 "gpt-4o-2024-05-13"      "gpt-4o-2024-08-06"     
+      [16] "gpt-4o-mini-2024-07-18"
+
+# get_available_models works for cohere
+
+    Code
+      models
+    Output
+      [1] "command-r"             "command-nightly"       "command-r-plus"       
+      [4] "c4ai-aya-23-35b"       "command-light-nightly" "c4ai-aya-23-8b"       
+      [7] "command"               "command-light"        
+
+# get_available_models works for google
+
+    Code
+      models
+    Output
+       [1] "chat-bison-001"               "text-bison-001"              
+       [3] "embedding-gecko-001"          "gemini-1.0-pro-latest"       
+       [5] "gemini-1.0-pro"               "gemini-pro"                  
+       [7] "gemini-1.0-pro-001"           "gemini-1.0-pro-vision-latest"
+       [9] "gemini-pro-vision"            "gemini-1.5-pro-latest"       
+      [11] "gemini-1.5-pro-001"           "gemini-1.5-pro"              
+      [13] "gemini-1.5-pro-exp-0801"      "gemini-1.5-flash-latest"     
+      [15] "gemini-1.5-flash-001"         "gemini-1.5-flash"            
+      [17] "gemini-1.5-flash-001-tuning"  "embedding-001"               
+      [19] "text-embedding-004"           "aqa"                         
+

--- a/tests/testthat/test-models.R
+++ b/tests/testthat/test-models.R
@@ -15,13 +15,7 @@ test_that("get_available_models works for openai", {
   skip_on_ci()
   service <- "openai"
   models <- get_available_models(service)
-  expect_equal(models, c(
-    "gpt-4o-mini",
-    "gpt-3.5-turbo", "gpt-3.5-turbo-0125", "gpt-3.5-turbo-1106",
-    "gpt-3.5-turbo-16k", "gpt-4", "gpt-4-0125-preview", "gpt-4-0613",
-    "gpt-4-1106-preview", "gpt-4-turbo", "gpt-4-turbo-2024-04-09",
-    "gpt-4-turbo-preview", "gpt-4o", "gpt-4o-2024-05-13", "gpt-4o-mini-2024-07-18"
-  ))
+  expect_snapshot(models)
 })
 
 test_that("get_available_models works for huggingface", {
@@ -73,23 +67,12 @@ test_that("get_available_models works for cohere", {
   skip_on_ci()
   service <- "cohere"
   models <- get_available_models(service)
-  expect_equal(models, c(
-    "command-r", "command-r-plus", "c4ai-aya-23",
-    "command-light-nightly", "command-nightly",
-    "command", "command-light"
-  ))
+  expect_snapshot(models)
 })
 
 test_that("get_available_models works for google", {
   skip_on_ci()
   service <- "google"
   models <- get_available_models(service)
-  expect_equal(models, c(
-    "chat-bison-001", "text-bison-001", "embedding-gecko-001",
-    "gemini-1.0-pro", "gemini-1.0-pro-001", "gemini-1.0-pro-latest",
-    "gemini-1.0-pro-vision-latest", "gemini-1.5-flash", "gemini-1.5-flash-001",
-    "gemini-1.5-flash-latest", "gemini-1.5-pro", "gemini-1.5-pro-001",
-    "gemini-1.5-pro-latest", "gemini-pro", "gemini-pro-vision",
-    "embedding-001", "text-embedding-004", "aqa"
-  ))
+  expect_snapshot(models)
 })

--- a/tests/testthat/test-service-azure_openai.R
+++ b/tests/testthat/test-service-azure_openai.R
@@ -1,0 +1,217 @@
+test_that("create_completion_azure_openai formats request correctly", {
+  mock_query_api <- function(task, request_body, base_url, deployment_name,
+                             api_key, api_version) {
+    list(choices = list(list(message = list(content = "Mocked response"))))
+  }
+
+  withr::with_envvar(
+    new = c(
+      AZURE_OPENAI_TASK = "env_task",
+      AZURE_OPENAI_ENDPOINT = "https://env.openai.azure.com",
+      AZURE_OPENAI_DEPLOYMENT_NAME = "env_deployment",
+      AZURE_OPENAI_API_KEY = "env_token",
+      AZURE_OPENAI_API_VERSION = "env_version"
+    ),
+    {
+      local_mocked_bindings(
+        query_api_azure_openai = mock_query_api
+      )
+
+      result <- create_completion_azure_openai("Test prompt")
+
+      expect_type(result, "list")
+      expect_equal(result$choices[[1]]$message$content, "Mocked response")
+    }
+  )
+})
+
+test_that("request_base_azure_openai constructs correct request", {
+  mock_request <- function(url) {
+    structure(list(url = url, headers = list()), class = "httr2_request")
+  }
+
+  mock_req_url_path_append <- function(req, path) {
+    req$url <- paste0(req$url, "/", path)
+    req
+  }
+
+  mock_req_url_query <- function(req, ...) {
+    req$url <- paste0(req$url, "?api-version=test_version")
+    req
+  }
+
+  mock_req_headers <- function(req, ...) {
+    req$headers <- list("api-key" = "test_token",
+                        "Content-Type" = "application/json")
+    req
+  }
+
+  withr::with_envvar(
+    new = c(AZURE_OPENAI_USE_TOKEN = "false"),
+    {
+      local_mocked_bindings(
+        request = mock_request,
+        req_url_path_append = mock_req_url_path_append,
+        req_url_query = mock_req_url_query,
+        req_headers = mock_req_headers
+      )
+
+      result <- request_base_azure_openai(
+        task = "test_task",
+        base_url = "https://test.openai.azure.com",
+        deployment_name = "test_deployment",
+        api_key = "test_token",
+        api_version = "test_version"
+      )
+
+      expect_equal(result$url, "https://test.openai.azure.com/openai/deployments/test_deployment/test_task?api-version=test_version")
+      expect_equal(result$headers, list("api-key" = "test_token",
+                                        "Content-Type" = "application/json"))
+    }
+  )
+})
+
+test_that("query_api_azure_openai handles successful response", {
+  mock_request_base <- function(...) {
+    structure(list(url = "https://test.openai.azure.com", headers = list()),
+              class = "httr2_request")
+  }
+
+  mock_req_perform <- function(req) {
+    structure(list(status_code = 200, body = '{"result": "success"}'),
+              class = "httr2_response")
+  }
+
+  mock_resp_body_json <- function(resp) list(result = "success")
+
+  local_mocked_bindings(
+    request_base_azure_openai = mock_request_base,
+    req_body_json = function(req, body) req,
+    req_retry = function(req, max_tries) req,
+    req_error = function(req, is_error) req,
+    req_perform = mock_req_perform,
+    resp_is_error = function(resp) FALSE,
+    resp_body_json = mock_resp_body_json
+  )
+
+  result <- query_api_azure_openai(
+    task = "test_task",
+    request_body = list(list(role = "user", content = "Test prompt")),
+    base_url = "https://test.openai.azure.com",
+    deployment_name = "test_deployment",
+    api_key = "test_token",
+    api_version = "test_version"
+  )
+
+  expect_type(result, "list")
+  expect_equal(result$result, "success")
+})
+
+test_that("query_api_azure_openai handles error response", {
+  mock_request_base <- function(...) {
+    structure(list(url = "https://test.openai.azure.com", headers = list()),
+              class = "httr2_request")
+  }
+
+  mock_req_perform <- function(req) {
+    structure(list(status_code = 400, body = '{"error": "Bad Request"}'),
+              class = "httr2_response")
+  }
+
+  local_mocked_bindings(
+    request_base_azure_openai = mock_request_base,
+    req_body_json = function(req, body) req,
+    req_retry = function(req, max_tries) req,
+    req_error = function(req, is_error) req,
+    req_perform = mock_req_perform,
+    resp_is_error = function(resp) TRUE,
+    resp_status = function(resp) 400,
+    resp_status_desc = function(resp) "Bad Request"
+  )
+
+  expect_error(
+    query_api_azure_openai(
+      task = "test_task",
+      request_body = list(list(role = "user", content = "Test prompt")),
+      base_url = "https://test.openai.azure.com",
+      deployment_name = "test_deployment",
+      api_key = "test_token",
+      api_version = "test_version"
+    ),
+    "Azure OpenAI API request failed. Error 400 - Bad Request"
+  )
+})
+
+# Test token retrieval --------------------------------------------------------
+
+test_that("retrieve_azure_token successfully gets existing token", {
+  local_mocked_bindings(
+    get_azure_login = function(...) list(token = list(credentials = list(access_token = "existing_token"))),
+    create_azure_login = function(...) stop("Should not be called"),
+    .package = "AzureRMR"
+  )
+
+  token <- retrieve_azure_token()
+
+  expect_equal(token, "existing_token")
+})
+
+test_that("retrieve_azure_token creates new token when get_azure_login fails", {
+  local_mocked_bindings(
+    get_azure_login = function(...) stop("Error"),
+    create_azure_login = function(...) list(token = list(credentials = list(access_token = "new_token"))),
+    .package = "AzureRMR"
+  )
+
+  token <- retrieve_azure_token()
+
+  expect_equal(token, "new_token")
+})
+
+test_that("retrieve_azure_token uses correct environment variables", {
+  mock_get_azure_login <- function(tenant, app, scopes) {
+    expect_equal(tenant, "test_tenant")
+    expect_equal(app, "test_client")
+    expect_equal(scopes, ".default")
+    stop("Error")
+  }
+
+  mock_create_azure_login <- function(tenant, app, password, host, scopes) {
+    expect_equal(tenant, "test_tenant")
+    expect_equal(app, "test_client")
+    expect_equal(password, "test_secret")
+    expect_equal(host, "https://cognitiveservices.azure.com/")
+    expect_equal(scopes, ".default")
+    list(token = list(credentials = list(access_token = "new_token")))
+  }
+
+  local_mocked_bindings(
+    get_azure_login = mock_get_azure_login,
+    create_azure_login = mock_create_azure_login,
+    .package = "AzureRMR"
+  )
+
+  withr::local_envvar(
+    AZURE_OPENAI_TENANT_ID = "test_tenant",
+    AZURE_OPENAI_CLIENT_ID = "test_client",
+    AZURE_OPENAI_CLIENT_SECRET = "test_secret"
+  )
+
+  expect_no_error(retrieve_azure_token())
+})
+
+test_that("retrieve_azure_token checks for AzureRMR installation", {
+  mock_check_installed <- function(pkg) {
+    expect_equal(pkg, "AzureRMR")
+  }
+
+  local_mocked_bindings(
+    check_installed = mock_check_installed,
+    .package = "rlang"
+  )
+
+  expect_no_error(tryCatch(
+    retrieve_azure_token(),
+    error = function(e) {}
+  ))
+})

--- a/tests/testthat/test-service-azure_openai.R
+++ b/tests/testthat/test-service-azure_openai.R
@@ -64,7 +64,7 @@ test_that("request_base_azure_openai constructs correct request", {
         api_version = "test_version"
       )
 
-      expect_equal(result$url, "https://test.openai.azure.com/openai/deployments/test_deployment/test_task?api-version=test_version")
+      expect_equal(result$url, "https://test.openai.azure.com/openai/deployments/test_deployment/test_task?api-version=test_version") #nolint
       expect_equal(result$headers, list("api-key" = "test_token",
                                         "Content-Type" = "application/json"))
     }
@@ -146,7 +146,9 @@ test_that("query_api_azure_openai handles error response", {
 
 test_that("retrieve_azure_token successfully gets existing token", {
   local_mocked_bindings(
-    get_azure_login = function(...) list(token = list(credentials = list(access_token = "existing_token"))),
+    get_azure_login = function(...) {
+      list(token = list(credentials = list(access_token = "existing_token")))
+    },
     create_azure_login = function(...) stop("Should not be called"),
     .package = "AzureRMR"
   )
@@ -159,7 +161,9 @@ test_that("retrieve_azure_token successfully gets existing token", {
 test_that("retrieve_azure_token creates new token when get_azure_login fails", {
   local_mocked_bindings(
     get_azure_login = function(...) stop("Error"),
-    create_azure_login = function(...) list(token = list(credentials = list(access_token = "new_token"))),
+    create_azure_login = function(...) {
+      list(token = list(credentials = list(access_token = "new_token")))
+    },
     .package = "AzureRMR"
   )
 

--- a/vignettes/azure.Rmd
+++ b/vignettes/azure.Rmd
@@ -21,7 +21,7 @@ To configure gptstudio to work using Azure OpenAI service, you need to provide s
 - AZURE_OPENAI_TASK
 - AZURE_OPENAI_ENDPOINT
 - AZURE_OPENAI_DEPLOYMENT_NAME
-- AZURE_OPENAI_KEY
+- AZURE_OPENAI_API_KEY
 - AZURE_OPENAI_API_VERSION
 - AZURE_OPENAI_USE_TOKEN
 
@@ -31,7 +31,7 @@ Here's how you can add these details to your .Renviron file:
 2. Add environment variable details: Add a new line for each variable you need to set in the following format: VARIABLE_NAME="YOUR_VALUE". Replace VARIABLE_NAME with the name of the environment variable and YOUR_VALUE with the actual value that you want to set. For example, to set the API key you would have a line like this:
 
 ```bash
-AZURE_OPENAI_KEY="your_actual_key_goes_here"
+AZURE_OPENAI_API_KEY="your_actual_key_goes_here"
 ```
 You need to do this for each of the environment variables expected by the function. Your .Renviron file should look something like this:
 
@@ -39,7 +39,7 @@ You need to do this for each of the environment variables expected by the functi
 AZURE_OPENAI_TASK="your_task_code"
 AZURE_OPENAI_ENDPOINT="your_endpoint_url"
 AZURE_OPENAI_DEPLOYMENT_NAME="your_deployment_name"
-AZURE_OPENAI_KEY="your_api_key"
+AZURE_OPENAI_API_KEY="your_api_key"
 AZURE_OPENAI_API_VERSION="your_api_version"
 AZURE_OPENAI_USE_TOKEN=FALSE
 ```


### PR DESCRIPTION
## Related issue

- Closes #218 
- Closes #187

## Description of changes

- Use `api_key` instead of `token` for Azure OpenAI
- Use cached token if available
- Add tests for Azure OpenAI service

## For contributors

- [x] I have added the relevant changes to the NEWS.md file
- [x] I have added relevant tests or documentation with my changes

## For reviewers

- [x] Changes meet the acceptance criteria of the related issue
- [x] The contribution follows style conventions and code of conduct
- [x] Branch passes automated testing
- [x] I have incremented the package version in the DESCRIPTION file before merging
