### PR TITLE
Add info tooltip to API service settings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gptstudio
 Title: Use Large Language Models Directly in your Development Environment
-Version: 0.4.0.9007
+Version: 0.4.0.9008
 Authors@R: c(
     person("Michel", "Nivard", , "m.g.nivard@vu.nl", role = c("aut", "cph")),
     person("James", "Wade", , "github@jameshwade.com", role = c("aut", "cre", "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - Replace curl calls with httr2. #224
 - Remove magrittr pipe in favor of base pipe, require R >= 4.1 #226
 - Tweak app sidebar and set min version of bsicons and httr2 #228
+- Added info tooltips to the API service settings to inform users to save after modifying this section #230
 
 ## gptstudio 0.4.0
 

--- a/R/mod_settings.R
+++ b/R/mod_settings.R
@@ -60,14 +60,20 @@ mod_settings_ui <- function(id, translator = create_translator()) {
       icon = bsicons::bs_icon("server"),
       selectInput(
         inputId = ns("service"),
-        label = translator$t("Select API Service"),
+        label = tags$span(
+          translator$t("Select API Service"),
+          bsicons::bs_icon("info-circle") |> bslib::tooltip("Save after modifying!")
+        ),
         choices = api_services,
         selected = getOption("gptstudio.service"),
         width = "100%"
       ),
       selectInput(
         inputId = ns("model"),
-        label = translator$t("Chat Model"),
+        label = tags$span(
+          translator$t("Chat Model"),
+          bsicons::bs_icon("info-circle") |> bslib::tooltip("Save after modifying!")
+        ),
         choices = getOption("gptstudio.model"),
         width = "100%",
         selected = getOption("gptstudio.model")


### PR DESCRIPTION
## Related issue

- Closes #230 

## Description of changes

- Added info tooltips to the API service settings to inform users to save after modifying this section

## For contributors

- [X] I have added the relevant changes to the NEWS.md file
- [x] I have added relevant tests or documentation with my changes

## For reviewers

- [x] Changes meet the acceptance criteria of the related issue
- [x] The contribution follows style conventions and code of conduct
- [x] Branch passes automated testing
- [ ] I have incremented the package version in the DESCRIPTION file before merging
