### PR TITLE
Improve `read_docs()` for R >= 4.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 - Tweak app sidebar and set min version of bsicons and httr2 #228
 - Added info tooltips to the API service settings to inform users to save after modifying this section #230
 - Fixed a bug in `gptstudio_sitrep()` that prevented it to correctly report an active `ANTHROPIC_API_KEY`
+- Fixed a bug that prevented the internal `read_docs()` function from picking up documentation for R versions greater than 4.4. [#243](https://github.com/MichelNivard/gptstudio/issues/243)
 
 ## gptstudio 0.4.0
 

--- a/R/read_docs.R
+++ b/R/read_docs.R
@@ -82,6 +82,12 @@ docs_get_inner_text <- function(x) {
 
 docs_get_sections <- function(children) {
   check_installed("rvest")
+
+  if (getRversion() >= "4.4") {
+    children <- children[[1]] |>
+      rvest::html_children()
+  }
+
   h3_locations <- children |>
     purrr::map_lgl(~ rvest::html_name(.x) == "h3") |>
     which()

--- a/tests/testthat/test-read-docs.R
+++ b/tests/testthat/test-read-docs.R
@@ -12,6 +12,32 @@ test_that("read_docs() matches all expected case types", {
   read_docs("stringr::str_view") |> expect_type("list")
 })
 
+test_that("read_docs() gets non null content when successful", {
+  # These expectations can fail when the tested documentations are changed by their authors
+  # when they fail, first try previous versions of the packages
+
+  str_view_docs <- read_docs("stringr::str_view")[[1]]
+  data.frame_docs <- read_docs("base::data.frame")[[1]]
+
+  expect_false(is.null(str_view_docs$pkg_ref))
+  expect_false(is.null(str_view_docs$topic))
+  expect_false(is.null(str_view_docs$inner_text))
+  expect_false(is.null(str_view_docs$inner_text$title))
+  expect_false(is.null(str_view_docs$inner_text$description))
+  expect_false(is.null(str_view_docs$inner_text$usage))
+  expect_false(is.null(str_view_docs$inner_text$arguments))
+  expect_false(is.null(str_view_docs$inner_text$examples))
+
+  expect_false(is.null(data.frame_docs$pkg_ref))
+  expect_false(is.null(data.frame_docs$topic))
+  expect_false(is.null(data.frame_docs$inner_text))
+  expect_false(is.null(data.frame_docs$inner_text$title))
+  expect_false(is.null(data.frame_docs$inner_text$description))
+  expect_false(is.null(data.frame_docs$inner_text$usage))
+  expect_false(is.null(data.frame_docs$inner_text$arguments))
+  expect_false(is.null(data.frame_docs$inner_text$examples))
+})
+
 test_that("read_docs() works in operators", {
   skip("To be implemented: work in operators")
 


### PR DESCRIPTION
## Related issue

- Closes #243 

## Description of changes

- Fixed a bug that prevented the internal `read_docs()` function from picking up documentation for R versions greater than 4.4

## For contributors

- [X] I have added the relevant changes to the NEWS.md file
- [X] I have added relevant tests or documentation with my changes

## For reviewers

- [ ] Changes meet the acceptance criteria of the related issue
- [ ] The contribution follows style conventions and code of conduct
- [ ] Branch passes automated testing
- [ ] I have incremented the package version in the DESCRIPTION file before merging
