### PR TITLE
Bugfix for chat app crashing when using azure service

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gptstudio
 Title: Use Large Language Models Directly in your Development Environment
-Version: 0.4.0.9017
+Version: 0.4.0.9018
 Authors@R: c(
     person("Michel", "Nivard", , "m.g.nivard@vu.nl", role = c("aut", "cph")),
     person("James", "Wade", , "github@jameshwade.com", role = c("aut", "cre", "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # gptstudio (development version)
 
+- Fixed a bug in Azure OpenAI service that prevented the chat app from working. #260
 - Added Chinese translation for all the text elements of the UI.
 - Fixed a bug in read_docs.R that wasn't correctly referencing the help docs of packages that contain a period (".") in their name. The code now deals with all valid R package names as defined by [CRAN](https://cran.r-project.org/doc/manuals/R-exts.html#The-DESCRIPTION-file)
 - Fixed a bug that showed the message "ChatGPT responded" even when other service was being used in "Chat in source" related addins. #213

--- a/R/api_perform_request.R
+++ b/R/api_perform_request.R
@@ -208,9 +208,9 @@ ellmer_chat.gptstudio_request_cohere <- function(skeleton, all_turns) {
 #' @export
 ellmer_chat.gptstudio_request_azure_openai <- function(skeleton, all_turns) {
   # Extract Azure-specific configuration from skeleton
-  endpoint <- skeleton$extras$endpoint
-  deployment_id <- skeleton$extras$deployment_name
-  api_version <- skeleton$extras$api_version %||% "2024-10-21"
+  endpoint <- skeleton$extras$extras$endpoint
+  deployment_id <- skeleton$extras$extras$deployment_name
+  api_version <- skeleton$extras$extras$api_version %||% "2024-10-21"
 
   chat <- ellmer::chat_azure_openai(
     endpoint = endpoint,

--- a/R/api_perform_request.R
+++ b/R/api_perform_request.R
@@ -208,9 +208,9 @@ ellmer_chat.gptstudio_request_cohere <- function(skeleton, all_turns) {
 #' @export
 ellmer_chat.gptstudio_request_azure_openai <- function(skeleton, all_turns) {
   # Extract Azure-specific configuration from skeleton
-  endpoint <- skeleton$endpoint
-  deployment_id <- skeleton$deployment_id
-  api_version <- skeleton$api_version %||% "2024-10-21"
+  endpoint <- skeleton$extras$endpoint
+  deployment_id <- skeleton$extras$deployment_name
+  api_version <- skeleton$extras$api_version %||% "2024-10-21"
 
   chat <- ellmer::chat_azure_openai(
     endpoint = endpoint,

--- a/R/api_skeletons.R
+++ b/R/api_skeletons.R
@@ -160,14 +160,22 @@ gptstudio_request_skeleton.azure_openai <- function(
         content = "You are an R chat assistant"
       )
     ),
-    stream = FALSE) {
+    stream = FALSE,
+    deployment_name = Sys.getenv("AZURE_OPENAI_DEPLOYMENT_NAME"),
+    api_version = Sys.getenv("AZURE_OPENAI_API_VERSION"),
+    endpoint = Sys.getenv("AZURE_OPENAI_ENDPOINT")) {
   new_gpstudio_request_skeleton(url,
     api_key,
     model,
     prompt,
     history,
     stream,
-    class = "gptstudio_request_azure_openai"
+    class = "gptstudio_request_azure_openai",
+    extras = list(
+      deployment_name = deployment_name,
+      api_version = api_version,
+      endpoint = endpoint
+    )
   )
 }
 

--- a/tests/testthat/_snaps/api_skeletons.md
+++ b/tests/testthat/_snaps/api_skeletons.md
@@ -317,7 +317,17 @@
       [1] TRUE
       
       $extras
-      list()
+      $extras$extras
+      $extras$extras$deployment_name
+      [1] ""
+      
+      $extras$extras$api_version
+      [1] ""
+      
+      $extras$extras$endpoint
+      [1] ""
+      
+      
       
       attr(,"class")
       [1] "gptstudio_request_azure_openai" "gptstudio_request_skeleton"    


### PR DESCRIPTION
## Related issue

- Closes #257 

## Description of changes

The skeleton for azure service was not passing the deployment_id, api_version, or endpoint variables through to ellmer. 

To fix this, I added these vars (defined by the users environment vars) in the `extras` param in `gptstudio_request_skeleton.azure_openai`, and then grab them with `skeleton$extras$extras` (R is weird sometimes!) in `ellmer_chat.gptstudio_request_azure_openai`.

## For contributors

- [x] I have added the relevant changes to the NEWS.md file
- [x] I have added relevant tests or documentation with my changes

## For reviewers

- [x] Changes meet the acceptance criteria of the related issue
- [x] The contribution follows style conventions and code of conduct
- [x] Branch passes automated testing
- [x] I have incremented the package version in the DESCRIPTION file before merging
